### PR TITLE
Fix color bug

### DIFF
--- a/src/model/Oval.java
+++ b/src/model/Oval.java
@@ -8,7 +8,7 @@ public class Oval extends Shape {
     public Oval(Point topLeft, MidiSynth midiSynth) {
         super(topLeft, midiSynth);
         instrument = 57; // trumpets
-        PLAYING_COLOR = new Color(0, 128, 128);
+        playingColor = new Color(0, 128, 128);
     }
 
     // EFFECTS: return true if this Oval contains the given point p, else return false

--- a/src/model/Rectangle.java
+++ b/src/model/Rectangle.java
@@ -8,7 +8,7 @@ public class Rectangle extends Shape {
     public Rectangle(Point topLeft, MidiSynth midiSynth) {
         super(topLeft, midiSynth);
         instrument = 33; // bass
-        PLAYING_COLOR = new Color(20, 189, 79);
+        playingColor = new Color(20, 189, 79);
     }
 
     // EFFECTS: return true if the given y value is within the bounds of the Shape

--- a/src/model/Shape.java
+++ b/src/model/Shape.java
@@ -6,8 +6,7 @@ import java.awt.*;
 
 
 public abstract class Shape {
-    protected static Color PLAYING_COLOR;
-
+    protected Color playingColor;
     protected int x;
     protected int y;
     protected int width;
@@ -27,7 +26,7 @@ public abstract class Shape {
         playLineCoord = 0;
         // Default values below. These are usually reassigned in subclasses.
         instrument = 0; // piano
-        PLAYING_COLOR = new Color(230, 158, 60);
+        playingColor = new Color(230, 158, 60);
     }
 
     public Shape(int x, int y, int w, int h) {
@@ -63,7 +62,7 @@ public abstract class Shape {
     public void draw(Graphics g) {
         Color save = g.getColor();
         if (selected) {
-            g.setColor(PLAYING_COLOR);
+            g.setColor(playingColor);
         } else {
             g.setColor(Color.white);
         }


### PR DESCRIPTION
Fixes bug whereby pressing play on a shape didn't play it's `PLAYING_COLOR`, but rather the colour of the last shape to be drawn on the canvas. Bug also occured when playing whole drawing, whereby all shapes would be played in that colour.